### PR TITLE
Redesign profile screen and add experience_total to Profile

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import AuthScreen from "@/components/AuthScreen";
-import TopNavbar from "@/components/TopNavBar";
 import { useAuth } from "@/contexts/AuthContext";
-import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
+import Ionicons from "@expo/vector-icons/Ionicons";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import React from "react";
 import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
@@ -41,33 +40,111 @@ export default function HomeScreen() {
     );
   }
 
+  // Format XP with commas for readability
+  const formatXP = (xp: number) => {
+    return xp.toLocaleString();
+  };
+
+  // Format UPRO Gold with 2 decimal places
+  const formatUPROGold = (gold: number) => {
+    return gold.toFixed(2);
+  };
+
   return (
-    <SafeAreaView className="flex-1 bg-gray-50">
-      <TopNavbar />
-      <View className="flex-1 items-center px-6">
-        <View className=" flex items-center justify-center w-[80%] h-[60%] mt-20">
-          <View className="flex-row justify-between items-center w-full mb-6">
-            <View className="flex-row items-center">
-              <Text className="text-lg font-semibold italic">
-                {currentProfile?.name}{" "}
-              </Text>
-              <Text className="text-lg font-semibold italic">
-                <MaterialCommunityIcons
-                  name="crown"
-                  size={20}
-                  color="gold"
-                  style={{ marginLeft: 5 }}
-                />
-                {currentProfile?.upro_gold}{" "}
-              </Text>
+    <SafeAreaView className="flex-1 bg-white">
+      {/* Top Header Section */}
+      <View className="px-6 pt-4 pb-6">
+        <TouchableOpacity className="mb-4">
+          <Ionicons name="arrow-back" size={24} color="#374151" />
+        </TouchableOpacity>
+        
+        <View className="items-center">
+          <Text className="text-2xl font-bold text-gray-800 mb-1">
+            {currentProfile?.name}
+          </Text>
+          <Text className="text-base text-gray-600">
+            {currentProfile?.playing_position || "Player"}
+          </Text>
+        </View>
+      </View>
+
+      {/* Avatar and Action Buttons Section */}
+      <View className="items-center mb-8">
+        {/* Avatar Placeholder */}
+        <View className="w-24 h-32 items-center mb-6">
+          {/* Head */}
+          <View className="w-16 h-16 bg-gray-300 rounded-full mb-2" />
+          {/* Body */}
+          <View className="w-12 h-12 bg-gray-300 rounded-t-full" />
+        </View>
+
+        {/* Action Buttons */}
+        <View className="flex-row space-x-4">
+          <TouchableOpacity className="bg-blue-500 px-6 py-3 rounded-lg shadow-sm">
+            <Text className="text-white font-bold">edit avatar</Text>
+          </TouchableOpacity>
+          <TouchableOpacity className="bg-blue-500 px-6 py-3 rounded-lg shadow-sm">
+            <Text className="text-white font-bold">share</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Statistics Cards Grid */}
+      <View className="px-6">
+        <View className="flex-row flex-wrap justify-between">
+          {/* Card 1 - XP */}
+          <View className="w-[48%] bg-gray-800 rounded-lg p-4 mb-4">
+            <View className="flex-row items-center mb-2">
+              <MaterialCommunityIcons name="flag" size={16} color="#10B981" />
             </View>
-            <TouchableOpacity className="flex-row items-center gap-1">
-              <FontAwesome5 name="user-friends" size={24} color="black" />
-              <Text className="text-lg font-semibold italic">COUNT</Text>
-            </TouchableOpacity>
+            <Text className="text-white text-2xl font-bold mb-1">
+              {formatXP(currentProfile?.experience_total || 0)}
+            </Text>
+            <Text className="text-white text-sm">Experience Points</Text>
           </View>
-          <View className="w-full flex-1 flex items-center justify-center bg-white rounded-lg shadow-lg">
-            <Text>Div for avatar section.</Text>
+
+          {/* Card 2 - UPRO Gold */}
+          <View className="w-[48%] bg-gray-800 rounded-lg p-4 mb-4">
+            <View className="flex-row items-center mb-2">
+              <MaterialCommunityIcons name="crown" size={16} color="#8B5CF6" />
+            </View>
+            <Text className="text-white text-2xl font-bold mb-1">
+              {formatUPROGold(currentProfile?.upro_gold || 0)}
+            </Text>
+            <Text className="text-white text-sm">UPRO Gold</Text>
+          </View>
+
+          {/* Card 3 - Age Group */}
+          <View className="w-[48%] bg-gray-800 rounded-lg p-4 mb-4">
+            <View className="flex-row items-center mb-2">
+              <MaterialCommunityIcons name="clock" size={16} color="#FFFFFF" />
+            </View>
+            <Text className="text-white text-2xl font-bold mb-1">
+              {currentProfile?.age_group || 0}
+            </Text>
+            <Text className="text-white text-sm">Age Group</Text>
+          </View>
+
+          {/* Card 4 - Weight */}
+          <View className="w-[48%] bg-gray-800 rounded-lg p-4 mb-4">
+            <View className="flex-row items-center mb-2">
+              <MaterialCommunityIcons name="circle" size={16} color="#10B981" />
+            </View>
+            <Text className="text-white text-2xl font-bold mb-1">
+              {currentProfile?.weight || 0}
+            </Text>
+            <Text className="text-white text-sm">Weight (kg)</Text>
+          </View>
+
+          {/* Card 5 - Height */}
+          <View className="w-[48%] bg-gray-800 rounded-lg p-4 mb-4">
+            <View className="flex-row items-center mb-2">
+              <MaterialCommunityIcons name="lightning-bolt" size={16} color="#10B981" />
+            </View>
+            <Text className="text-white text-2xl font-bold mb-1">
+              {currentProfile?.height || 0}
+            </Text>
+            <Text className="text-white text-sm">Height (cm)</Text>
           </View>
         </View>
       </View>

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -28,6 +28,7 @@ export type Profile = {
   upro_gold: number;
   dominant_foot: string;
   playing_position: string;
+  experience_total: number;
   created_at: string;
   subscription_type: number;
   profile_picture: string | null;


### PR DESCRIPTION
Refactored the profile (HomeScreen) UI for improved layout, including avatar, action buttons, and a statistics grid with formatted values. Added the experience_total field to the Profile type in AuthContext to support display of experience points.

##
Discrod name maksymlan
---

### 📌 **Description**
Did issue 54 and included more stuff in a pretty format 

---

### 🔍 **How to Test**

Input various data 

---

### 📷 **Screenshots / Demo**
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/489c0efe-abe0-4fcd-a5bb-849b7e42c40c" />



---

### 📎 **Related Issues**
https://github.com/BuildersLeague/upro-mobile/issues/54
